### PR TITLE
Fix: Jacoco instrument exception in org.wso2.carbon.rule.backend

### DIFF
--- a/components/rule/org.wso2.carbon.rule.backend/pom.xml
+++ b/components/rule/org.wso2.carbon.rule.backend/pom.xml
@@ -101,6 +101,8 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
 		<configuration>
 			<excludes>
+				<!--Skip the dependency class irrelavant to the code coverage calculation. 
+				This contain methods which exceed the maximum method size limit in jacoco agent-->
 				<exclude>org/drools/compiler/lang/DRL6Lexer</exclude>
 			</excludes>
 		</configuration>

--- a/components/rule/org.wso2.carbon.rule.backend/pom.xml
+++ b/components/rule/org.wso2.carbon.rule.backend/pom.xml
@@ -99,6 +99,11 @@
 	    <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+		<configuration>
+			<excludes>
+				<exclude>org/drools/compiler/lang/DRL6Lexer</exclude>
+			</excludes>
+		</configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Purpose
Skip a class contains a method which exceed jacoco agent method size limit in drools dependency from jacoco coverage analysis as it is irrelevant to the code coverage calculation