### PR TITLE
Avoid importing org.wso2.carbon.core.server feature def

### DIFF
--- a/features/mediation/org.wso2.carbon.rule.mediation.server.feature/pom.xml
+++ b/features/mediation/org.wso2.carbon.rule.mediation.server.feature/pom.xml
@@ -146,9 +146,6 @@
                                 <bundleDef>org.wso2.orbit.net.sourceforge.jexcelapi:jxl</bundleDef>
                                 <bundleDef>org.wso2.orbit.jsr94:jsr94</bundleDef>
                             </bundles>
-                            <importFeatures>
-                                <importFeatureDef>org.wso2.carbon.core.server:${carbon.kernel.version}</importFeatureDef>
-                            </importFeatures>
                             <includedFeatures>
                                 <includedFeatureDef>
                                     org.wso2.carbon.rules:org.wso2.carbon.rule.mediation.common.feature


### PR DESCRIPTION
So that org.wso2.carbon.rule.mediation.server.feature can be packed with Micro Integrator which fixes wso2/product-ei#4041.