### PR TITLE
Replacing jxl with poi due to LGPL licence being used by jxl.

### DIFF
--- a/features/mediation/org.wso2.carbon.rule.mediation.server.feature/pom.xml
+++ b/features/mediation/org.wso2.carbon.rule.mediation.server.feature/pom.xml
@@ -75,8 +75,8 @@
             <artifactId>janino</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.net.sourceforge.jexcelapi</groupId>
-            <artifactId>jxl</artifactId>
+            <groupId>org.wso2.orbit.org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.jsr94</groupId>
@@ -143,7 +143,7 @@
                                 <bundleDef>antlr.wso2:antlr</bundleDef>
                                 <bundleDef>org.antlr.wso2:antlr-runtime</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.codehaus.janino:janino</bundleDef>
-                                <bundleDef>org.wso2.orbit.net.sourceforge.jexcelapi:jxl</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.poi:poi:${poi.orbit.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.jsr94:jsr94</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/features/service/org.wso2.carbon.rule.service.server.feature/pom.xml
+++ b/features/service/org.wso2.carbon.rule.service.server.feature/pom.xml
@@ -79,8 +79,8 @@
             <artifactId>janino</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.orbit.net.sourceforge.jexcelapi</groupId>
-            <artifactId>jxl</artifactId>
+            <groupId>org.wso2.orbit.org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wso2.orbit.jsr94</groupId>
@@ -148,7 +148,7 @@
                                 <bundleDef>antlr.wso2:antlr</bundleDef>
                                 <bundleDef>org.antlr.wso2:antlr-runtime</bundleDef>
                                 <bundleDef>org.wso2.orbit.org.codehaus.janino:janino</bundleDef>
-                                <bundleDef>org.wso2.orbit.net.sourceforge.jexcelapi:jxl</bundleDef>
+                                <bundleDef>org.wso2.orbit.org.apache.poi:poi:${poi.orbit.version}</bundleDef>
                                 <bundleDef>org.wso2.orbit.jsr94:jsr94</bundleDef>
                             </bundles>
                             <importFeatures>

--- a/pom.xml
+++ b/pom.xml
@@ -190,9 +190,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wso2.orbit.net.sourceforge.jexcelapi</groupId>
-                <artifactId>jxl</artifactId>
-                <version>${orbit.version.jxl}</version>
+                <groupId>org.wso2.orbit.org.apache.poi</groupId>
+                <artifactId>poi</artifactId>
+                <version>${poi.orbit.version}</version>
             </dependency>
 
             <dependency>
@@ -566,7 +566,7 @@
         <!-- Drools Versions -->
         <orbit.version.drools>6.3.0.wso2v1</orbit.version.drools>
         <orbit.version.jsr94>1.1.0.wso2v1</orbit.version.jsr94>
-        <orbit.version.jxl>2.6.12.wso2v1</orbit.version.jxl>
+        <poi.orbit.version>3.17.0.wso2v1</poi.orbit.version>
         <orbit.version.janino>2.5.15.wso2v1</orbit.version.janino>
         <orbit.version.joda-time>2.9.4.wso2v1</orbit.version.joda-time>
         <version.mvel>2.2.4.Final</version.mvel>


### PR DESCRIPTION
## Purpose
>  $ subject

## Goals
> Remove LGPL dependency.

Since both jxl and poi provide excel functionality and POI is with Apache 2.0 Licence , replacing jxl with it.

Ref:- https://stackoverflow.com/questions/14980717/what-is-the-better-api-to-reading-excel-sheets-in-java-jxl-or-apache-poi